### PR TITLE
Added libcupti path to Linux GPU support documentation

### DIFF
--- a/tensorflow/g3doc/get_started/os_setup.md
+++ b/tensorflow/g3doc/get_started/os_setup.md
@@ -444,7 +444,7 @@ variables.  Consider adding the commands below to your `~/.bash_profile`.  These
 assume your CUDA installation is in `/usr/local/cuda`:
 
 ```bash
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
 export CUDA_HOME=/usr/local/cuda
 ```
 


### PR DESCRIPTION
Added path to libcupti in the documentation for enabling Linux GPU support.
Without this library being in LD path certain tutorials (e.g. https://www.tensorflow.org/versions/master/how_tos/graph_viz/index.html) crash with message "tensorflow/stream_executor/dso_loader.cc:102] Couldn't open CUDA library libcupti.so."; if installed under these instructions and run under e.g. Jupyter.

This is also referenced in https://github.com/tensorflow/tensorflow/issues/2626
